### PR TITLE
Updated common_lib.h

### DIFF
--- a/include/common_lib.h
+++ b/include/common_lib.h
@@ -33,7 +33,7 @@ using namespace Eigen;
 #define STD_VEC_FROM_EIGEN(mat)  vector<decltype(mat)::Scalar> (mat.data(), mat.data() + mat.rows() * mat.cols())
 #define DEBUG_FILE_DIR(name)     (string(string(ROOT_DIR) + "Log/"+ name))
 
-typedef fast_lio::Pose6D Pose6D;
+typedef fast_lio_localization::Pose6D Pose6D;
 typedef pcl::PointXYZINormal PointType;
 typedef pcl::PointCloud<PointType> PointCloudXYZI;
 typedef vector<PointType, Eigen::aligned_allocator<PointType>>  PointVector;


### PR DESCRIPTION
Error fast_lio/Pose6D.h: No such file or directory

Solved by changing line 36 in common_lib.h
typedef fast_lio::Pose6D Pose6D; 
to
typedef fast_lio_localization::Pose6D Pose6D;